### PR TITLE
Convert TCS-IRIS ICD (CCR08) to model files

### DIFF
--- a/iris/component-model.conf
+++ b/iris/component-model.conf
@@ -1,0 +1,19 @@
+subsystem = TCS
+component = cmIRIS
+
+title = "Telescope Control IRIS Corrections Module"
+prefix = tcs.cm.iris
+componentType = Assembly
+
+description = """
+The TCS provides telemetry streams to control several components of IRIS:
+
+* **OIWFS probe arms**: The three arms are continuously positioned over guide stars.
+* **4 ADCs**: One fore each OIWFS probe arm, and one for the imager.
+* **rotator**: IRIS is rotated to compensate sidereal rotation and changes in pupil rotation, thus maintaining a stable scientific image.
+*
+"""
+
+modelVersion = "1.0"  // version of model in use for component
+wbsId = TMT.TCS.CM.IRIS
+

--- a/iris/publish-model.conf
+++ b/iris/publish-model.conf
@@ -1,0 +1,845 @@
+subsystem               = TCS
+component               = cmIRIS
+
+publish {
+
+  telemetry          = [
+    {
+      name              = imgCurAtmDispersion
+      description       = """
+       The TCS publishes the IRIS imager dispersion information at the current telescope location.
+       The entire event is published atomically so that all published subcomponents are synchronized.
+       """
+      minRate           = 1
+      maxRate           = 1
+      archive           = true
+      attributes        = [
+        {
+          name          = referenceWavelength
+          description   = "The reference wavelength is the wavelength at which the computed dispersion is reported by the TCS as 0. Range is TBC."
+          type          = double
+          minimum       = 0.5
+          maximum       = 3.0
+          units         = microns
+        }
+        {
+          name          = orientation
+          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of the ICRS."
+          type          = double
+          minimum       = -180
+          maximum       = 180
+          units         = degrees
+        }
+        {
+          name          = numElem
+          description   = "Number of entries (each) in the wavelengths, weights and dispersion elements. Range is TBC"
+          type          = integer
+          minimum       = 1
+          maximum       = 30
+        }
+        {
+          name          = wavelength
+          description   = "An array of wavelengths. Each provided wavelength value must be unique. Range is TBC"
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          minimum       = 0.5
+          maximum       = 3.0
+          units         = microns
+          items         = {
+            type        = double
+          }
+        }
+        {
+          name          = weight
+          description   = "An array of weights. They must sum to 1.0."
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          minimum       = 0.0
+          maximum       = 1.0
+          items         = {
+            type        = double
+          }
+        }
+        {
+          name          = dispersion
+          description   = "An array of atmospheric dispersion values."
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          units         = arcsec on sky
+          items         = {
+            type        = double
+          }
+        }
+      ]
+    }
+
+    {
+      name              = imgNewAtmDispersion
+      description       = """
+      The TCS publishes a single new IRIS Imager Dispersion event each time a new target is to be acquired.
+      Information is pertinent to the new target location.
+      """
+      archive           = true
+      attributes        = [
+        {
+          name          = referenceWavelength
+          description   = "The reference wavelength is the wavelength at which the computed dispersion is reported by the TCS as 0. Range is TBC."
+          type          = double
+          minimum       = 0.5
+          maximum       = 3.0
+          units         = microns
+        }
+        {
+          name          = orientation
+          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of ICRS."
+          type          = double
+          minimum       = -180
+          maximum       = 180
+          units         = degrees
+        }
+        {
+          name          = numElem
+          description   = "Number of entries (each) in the wavelengths, weights and dispersion elements. Range is TBC."
+          type          = integer
+          minimum       = 1
+          maximum       = 30
+        }
+        {
+          name          = wavelength
+          description   = "An array of wavelengths. Each provided wavelength value must be unique. Range is TBC (0.6 to 0.8 if restricted to NGS path)."
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          minimum       = 0.5
+          maximum       = 3.0
+          units         = microns
+          items         = {
+            type        = double
+          }
+        }
+        {
+          name          = weight
+          description   = "An array of weights. They must sum to 1.0."
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          minimum       = 0.0
+          maximum       = 1.0
+          items         = {
+            type        = double
+          }
+        }
+        {
+          name          = dispersion
+          description   = "An array of atmospheric dispersion values."
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          units         = arcsec on sky
+          items         = {
+            type        = double
+          }
+        }
+        {
+          name          = counter
+          description   = "Unique TCS counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
+          type          = long
+        }
+      ]
+    }
+
+
+
+    {
+      name              = oiwfs1CurAtmDispersion
+      description       = """
+       The TCS publishes the IRIS OIWFS dispersion information (one for each probe) at the current telescope location.
+       """
+      minRate           = 1
+      maxRate           = 1
+      archive           = true
+      attributes        = [
+        {
+          name          = referenceWavelength
+          description   = "The reference wavelength is the wavelength at which the computed dispersion is reported by the TCS as 0. Range is TBC."
+          type          = double
+          minimum       = 0.5
+          maximum       = 3.0
+          units         = microns
+        }
+        {
+          name          = orientation
+          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of the ICRS."
+          type          = double
+          minimum       = -180
+          maximum       = 180
+          units         = degrees
+        }
+        {
+          name          = numElem
+          description   = "Number of entries (each) in the wavelengths, weights and dispersion elements. Range is TBC"
+          type          = integer
+          minimum       = 1
+          maximum       = 30
+        }
+        {
+          name          = wavelength
+          description   = "An array of wavelengths. Each provided wavelength value must be unique. Range is TBC"
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          minimum       = 0.5
+          maximum       = 3.0
+          units         = microns
+          items         = {
+            type        = double
+          }
+        }
+        {
+          name          = weight
+          description   = "An array of weights. They must sum to 1.0."
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          minimum       = 0.0
+          maximum       = 1.0
+          items         = {
+            type        = double
+          }
+        }
+        {
+          name          = dispersion
+          description   = "An array of atmospheric dispersion values."
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          units         = arcsec on sky
+          items         = {
+            type        = double
+          }
+        }
+      ]
+    }
+
+    {
+      name              = oiwfs1NewAtmDispersion
+      description       = """
+      The TCS publishes single new IRIS OIWFS Dispersion events (one for each probe) each time a new target is to be acquired.
+      Information is pertinent to the new target location.
+      """
+      archive           = true
+      attributes        = [
+        {
+          name          = referenceWavelength
+          description   = "The reference wavelength is the wavelength at which the computed dispersion is reported by the TCS as 0. Range is TBC."
+          type          = double
+          minimum       = 0.5
+          maximum       = 3.0
+          units         = microns
+        }
+        {
+          name          = orientation
+          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of ICRS."
+          type          = double
+          minimum       = -180
+          maximum       = 180
+          units         = degrees
+        }
+        {
+          name          = numElem
+          description   = "Number of entries (each) in the wavelengths, weights and dispersion elements. Range is TBC."
+          type          = integer
+          minimum       = 1
+          maximum       = 30
+        }
+        {
+          name          = wavelength
+          description   = "An array of wavelengths. Each provided wavelength value must be unique. Range is TBC (0.6 to 0.8 if restricted to NGS path)."
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          minimum       = 0.5
+          maximum       = 3.0
+          units         = microns
+          items         = {
+            type        = double
+          }
+        }
+        {
+          name          = weight
+          description   = "An array of weights. They must sum to 1.0."
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          minimum       = 0.0
+          maximum       = 1.0
+          items         = {
+            type        = double
+          }
+        }
+        {
+          name          = dispersion
+          description   = "An array of atmospheric dispersion values."
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          units         = arcsec on sky
+          items         = {
+            type        = double
+          }
+        }
+        {
+          name          = counter
+          description   = "Unique TCS counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
+          type          = long
+        }
+      ]
+    }
+
+    {
+      name              = oiwfs2CurAtmDispersion
+      description       = """
+       The TCS publishes the IRIS OIWFS dispersion information (one for each probe) at the current telescope location.
+       """
+      minRate           = 1
+      maxRate           = 1
+      archive           = true
+      attributes        = [
+        {
+          name          = referenceWavelength
+          description   = "The reference wavelength is the wavelength at which the computed dispersion is reported by the TCS as 0. Range is TBC."
+          type          = double
+          minimum       = 0.5
+          maximum       = 3.0
+          units         = microns
+        }
+        {
+          name          = orientation
+          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of the ICRS."
+          type          = double
+          minimum       = -180
+          maximum       = 180
+          units         = degrees
+        }
+        {
+          name          = numElem
+          description   = "Number of entries (each) in the wavelengths, weights and dispersion elements. Range is TBC"
+          type          = integer
+          minimum       = 1
+          maximum       = 30
+        }
+        {
+          name          = wavelength
+          description   = "An array of wavelengths. Each provided wavelength value must be unique. Range is TBC"
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          minimum       = 0.5
+          maximum       = 3.0
+          units         = microns
+          items         = {
+            type        = double
+          }
+        }
+        {
+          name          = weight
+          description   = "An array of weights. They must sum to 1.0."
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          minimum       = 0.0
+          maximum       = 1.0
+          items         = {
+            type        = double
+          }
+        }
+        {
+          name          = dispersion
+          description   = "An array of atmospheric dispersion values."
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          units         = arcsec on sky
+          items         = {
+            type        = double
+          }
+        }
+      ]
+    }
+
+    {
+      name              = oiwfs2NewAtmDispersion
+      description       = """
+      The TCS publishes single new IRIS OIWFS Dispersion events (one for each probe) each time a new target is to be acquired.
+      Information is pertinent to the new target location.
+      """
+      archive           = true
+      attributes        = [
+        {
+          name          = referenceWavelength
+          description   = "The reference wavelength is the wavelength at which the computed dispersion is reported by the TCS as 0. Range is TBC."
+          type          = double
+          minimum       = 0.5
+          maximum       = 3.0
+          units         = microns
+        }
+        {
+          name          = orientation
+          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of ICRS."
+          type          = double
+          minimum       = -180
+          maximum       = 180
+          units         = degrees
+        }
+        {
+          name          = numElem
+          description   = "Number of entries (each) in the wavelengths, weights and dispersion elements. Range is TBC."
+          type          = integer
+          minimum       = 1
+          maximum       = 30
+        }
+        {
+          name          = wavelength
+          description   = "An array of wavelengths. Each provided wavelength value must be unique. Range is TBC (0.6 to 0.8 if restricted to NGS path)."
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          minimum       = 0.5
+          maximum       = 3.0
+          units         = microns
+          items         = {
+            type        = double
+          }
+        }
+        {
+          name          = weight
+          description   = "An array of weights. They must sum to 1.0."
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          minimum       = 0.0
+          maximum       = 1.0
+          items         = {
+            type        = double
+          }
+        }
+        {
+          name          = dispersion
+          description   = "An array of atmospheric dispersion values."
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          units         = arcsec on sky
+          items         = {
+            type        = double
+          }
+        }
+        {
+          name          = counter
+          description   = "Unique TCS counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
+          type          = long
+        }
+      ]
+    }
+
+
+    {
+      name              = oiwfs3CurAtmDispersion
+      description       = """
+       The TCS publishes the IRIS OIWFS dispersion information (one for each probe) at the current telescope location.
+       """
+      minRate           = 1
+      maxRate           = 1
+      archive           = true
+      attributes        = [
+        {
+          name          = referenceWavelength
+          description   = "The reference wavelength is the wavelength at which the computed dispersion is reported by the TCS as 0. Range is TBC."
+          type          = double
+          minimum       = 0.5
+          maximum       = 3.0
+          units         = microns
+        }
+        {
+          name          = orientation
+          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of the ICRS."
+          type          = double
+          minimum       = -180
+          maximum       = 180
+          units         = degrees
+        }
+        {
+          name          = numElem
+          description   = "Number of entries (each) in the wavelengths, weights and dispersion elements. Range is TBC"
+          type          = integer
+          minimum       = 1
+          maximum       = 30
+        }
+        {
+          name          = wavelength
+          description   = "An array of wavelengths. Each provided wavelength value must be unique. Range is TBC"
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          minimum       = 0.5
+          maximum       = 3.0
+          units         = microns
+          items         = {
+            type        = double
+          }
+        }
+        {
+          name          = weight
+          description   = "An array of weights. They must sum to 1.0."
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          minimum       = 0.0
+          maximum       = 1.0
+          items         = {
+            type        = double
+          }
+        }
+        {
+          name          = dispersion
+          description   = "An array of atmospheric dispersion values."
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          units         = arcsec on sky
+          items         = {
+            type        = double
+          }
+        }
+      ]
+    }
+
+    {
+      name              = oiwfs3NewAtmDispersion
+      description       = """
+      The TCS publishes single new IRIS OIWFS Dispersion events (one for each probe) each time a new target is to be acquired.
+      Information is pertinent to the new target location.
+      """
+      archive           = true
+      attributes        = [
+        {
+          name          = referenceWavelength
+          description   = "The reference wavelength is the wavelength at which the computed dispersion is reported by the TCS as 0. Range is TBC."
+          type          = double
+          minimum       = 0.5
+          maximum       = 3.0
+          units         = microns
+        }
+        {
+          name          = orientation
+          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of ICRS."
+          type          = double
+          minimum       = -180
+          maximum       = 180
+          units         = degrees
+        }
+        {
+          name          = numElem
+          description   = "Number of entries (each) in the wavelengths, weights and dispersion elements. Range is TBC."
+          type          = integer
+          minimum       = 1
+          maximum       = 30
+        }
+        {
+          name          = wavelength
+          description   = "An array of wavelengths. Each provided wavelength value must be unique. Range is TBC (0.6 to 0.8 if restricted to NGS path)."
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          minimum       = 0.5
+          maximum       = 3.0
+          units         = microns
+          items         = {
+            type        = double
+          }
+        }
+        {
+          name          = weight
+          description   = "An array of weights. They must sum to 1.0."
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          minimum       = 0.0
+          maximum       = 1.0
+          items         = {
+            type        = double
+          }
+        }
+        {
+          name          = dispersion
+          description   = "An array of atmospheric dispersion values."
+          type          = array
+          minItems      = 1
+          maxItems      = 30
+          units         = arcsec on sky
+          items         = {
+            type        = double
+          }
+        }
+        {
+          name          = counter
+          description   = "Unique TCS counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
+          type          = long
+        }
+      ]
+    }
+
+    {
+      name              = oiwfs1pointingStatus
+      description       = """
+      The TCS publishes current pointing status events for each OIWFS probe arm independently, each time the state changes.
+      """
+      archive           = true
+      attributes        = [
+        {
+          name          = state
+          description   = "Current state of the pointing system"
+          enum          = [Slewing,Tracking,InPosition]
+        }
+        {
+          name          = counter
+          description   = "Current target counter (incrementing with rollover)"
+          type          = long
+        }
+      ]
+    }
+
+    {
+      name              = oiwfs2pointingStatus
+      description       = """
+      The TCS publishes current pointing status events for each OIWFS probe arm independently, each time the state changes.
+      """
+      archive           = true
+      attributes        = [
+        {
+          name          = state
+          description   = "Current state of the pointing system"
+          enum          = [Slewing,Tracking,InPosition]
+        }
+        {
+          name          = counter
+          description   = "Current target counter (incrementing with rollover)"
+          type          = long
+        }
+      ]
+    }
+
+    {
+      name              = oiwfs3pointingStatus
+      description       = """
+      The TCS publishes current pointing status events for each OIWFS probe arm independently, each time the state changes.
+      """
+      archive           = true
+      attributes        = [
+        {
+          name          = state
+          description   = "Current state of the pointing system"
+          enum          = [Slewing,Tracking,InPosition]
+        }
+        {
+          name          = counter
+          description   = "Current target counter (incrementing with rollover)"
+          type          = long
+        }
+      ]
+    }
+
+    {
+      name              = instrumentRotatorAngle
+      description       = """
+      The TCS publishes the timestamped current IRIS instrument rotator angle.
+      """
+      minRate           = 20
+      maxRate           = 20
+      archive           = true
+      attributes        = [
+        {
+          name          = instrumentAngle
+          description   = "Current rotator angle in the XY plane of the FCRS<sub>BP</sub>."
+          type          = double
+          minimum       = -135
+          maximum       = 135
+          units         = degrees
+        }
+        {
+          name          = instrumentAngleTimestamp
+          description   = "Associated timestamp (units TBD)"
+          type          = double
+          units         = mjd
+        }
+      ]
+    }
+
+    {
+      name              = pupilRotation
+      description       = """
+      The TCS publishes the timestamped current pupil rotation angle.
+      """
+      minRate           = 20
+      maxRate           = 20
+      archive           = true
+      attributes        = [
+        {
+          name          = pupilRotation
+          description   = "Current IRIS pupil rotation angle in the X,Y plane of the ICRS."
+          type          = double
+          minimum       = 90
+          maximum       = 180
+          units         = degrees
+        }
+        {
+          name          = pupilRotationTimestamp
+          description   = "Associated timestamp (units TBD)"
+          type          = double
+          units         = mjd
+        }
+      ]
+    }
+
+    {
+      name              = oiwfsProbeDemands
+      description       = """
+      The TCS publishes the timestamped focal plane locations and velocities for each IRIS OIWFS at some TBD time in the future.
+      """
+      minRate           = 20
+      maxRate           = 20
+      archive           = true
+      attributes        = [
+        {
+          name          = oiwfs1Pos
+          description   = "2-element array holding x,y values in the ICRS."
+          type          = array
+          dimensions: [2]
+          units = mm
+          items = {
+            type = double
+          }
+        }
+        {
+          name          = oiwfs2Pos
+          description   = "2-element array holding x,y values in the ICRS."
+          type          = array
+          dimensions: [2]
+          units = mm
+          items = {
+            type = double
+          }
+        }
+        {
+          name          = oiwfs3Pos
+          description   = "2-element array holding x,y values in the ICRS."
+          type          = array
+          dimensions: [2]
+          units = mm
+          items = {
+            type = double
+          }
+        }
+        {
+          name          = oiwfs1Vel
+          description   = "2-element array holding x,y values in the ICRS."
+          type          = array
+          dimensions: [2]
+          units = mm/s
+          items = {
+            type = double
+          }
+        }
+        {
+          name          = oiwfs2Vel
+          description   = "2-element array holding x,y values in the ICRS."
+          type          = array
+          dimensions: [2]
+          units = mm/s
+          items = {
+            type = double
+          }
+        }
+        {
+          name          = oiwfs3Vel
+          description   = "2-element array holding x,y values in the ICRS."
+          type          = array
+          dimensions: [2]
+          units = mm/s
+          items = {
+            type = double
+          }
+        }
+        {
+          name          = oiwfsPositionTimestamp
+          description   = "Timestamp these are applicable (units TBD)"
+          type          = double
+          units         = mjd
+        }
+      ]
+    }
+
+    {
+      name              = odgwPosDemands
+      description       = """
+      The TCS publishes the timestamped focal plane locations for each IRIS ODGW at some TBD time in the future.
+      """
+      minRate           = 20
+      maxRate           = 20
+      archive           = true
+      attributes        = [
+        {
+          name          = odgw1Pos
+          description   = "2-element array holding x,y values in the ICRS."
+          type          = array
+          dimensions: [2]
+          units = mm
+          items = {
+            type = double
+          }
+        }
+        {
+          name          = odgw2Pos
+          description   = "2-element array holding x,y values in the ICRS."
+          type          = array
+          dimensions: [2]
+          units = mm
+          items = {
+            type = double
+          }
+        }
+        {
+          name          = odgw3Pos
+          description   = "2-element array holding x,y values in the ICRS."
+          type          = array
+          dimensions: [2]
+          units = mm
+          items = {
+            type = double
+          }
+        }
+        {
+          name          = odgw4Pos
+          description   = "2-element array holding x,y values in the ICRS."
+          type          = array
+          dimensions: [2]
+          units = mm
+          items = {
+            type = double
+          }
+        }
+        {
+          name          = odgwPositionTimestamp
+          description   = "Timestamp these are applicable (units TBD)"
+          type          = double
+          units         = mjd
+        }
+      ]
+    }
+
+  ]
+
+}

--- a/iris/publish-model.conf
+++ b/iris/publish-model.conf
@@ -16,7 +16,11 @@ publish {
       attributes        = [
         {
           name          = referenceWavelength
-          description   = "The reference wavelength is the wavelength at which the computed dispersion is reported by the TCS as 0. Range is TBC."
+          description   = """
+          The reference wavelength is the wavelength at which the computed dispersion is reported by the TCS as 0. Range is TBC.
+
+          *Discussion: The relative dispersion is reported about a reference dispersion at this wavelength. The expected ADC image shifts are also computed at the reference wavelength.*
+          """
           type          = double
           minimum       = 0.5
           maximum       = 3.0
@@ -24,7 +28,11 @@ publish {
         }
         {
           name          = orientation
-          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of the ICRS."
+          description   = """
+          Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of the FCRS<sub>IRIS-ROT</sub>.
+
+           *Discussion: During LGS, NGS or seeing limited operations, the IRIS Imager ADC prism rotation angles are updated based on the Imager Atmospheric Dispersion data. The orientation angle is used to align the ADC axis of correction along the axis of dispersion.*
+          """
           type          = double
           minimum       = -180
           maximum       = 180
@@ -32,14 +40,22 @@ publish {
         }
         {
           name          = numElem
-          description   = "Number of entries (each) in the wavelengths, weights and dispersion elements. Range is TBC"
+          description   = """
+          Number of entries (each) in the wavelengths, weights and dispersion elements. Range is TBC.
+
+          *Discussion: The numElem field represents the number of distinct wavelengths of dispersion information. The wavelength, weight and dispersion arrays each contain exactly numElem values. It is expected that the number of elements is large enough to provide the general shape of the dispersion over the required wavelength range. In a simplified mode of operation at which a specific setting of the ADC is desired for correction at a particular wavelength, numElem will be 1.*
+          """
           type          = integer
           minimum       = 1
           maximum       = 30
         }
         {
           name          = wavelength
-          description   = "An array of wavelengths. Each provided wavelength value must be unique. Range is TBC"
+          description   = """
+          An array of wavelengths. Each provided wavelength value must be unique. Range is TBC.
+
+          *Discussion: The wavelength field represents the distinct wavelengths for which dispersion information is provided by the TCS. It is TBD whether the TCS will provide the same range of wavelengths for all ADC control or whether each ADC would only receive a restricted range of wavelengths based on the range of light that it would be correcting. The number of wavelength values provided must be exactly equal to the value of numElem. In a simplified mode of operation at which a specific setting of the ADC is desired for correction at a particular wavelength, only that wavelength will be specified.*
+          """
           type          = array
           minItems      = 1
           maxItems      = 30
@@ -52,7 +68,12 @@ publish {
         }
         {
           name          = weight
-          description   = "An array of weights. They must sum to 1.0."
+          description   = """
+          An array of weights. They must sum to 1.0.
+
+          *Discussion: The weight field represents a weighting function to be applied to the dispersion curve; this weighting function from the TCS may include telescope throughput and source spectral energy distribution, although it is TBD whether all of these components are combined into this single function, or whether it is pieced together from several locations. This weight will not contain information local to the imager, such as the selected filter and detector quantum efficient. The number of weight values provided must be exactly equal to the value of numElem. Each weight must be non-negative and the sum of the weights is normalized to unity.*
+
+          """
           type          = array
           minItems      = 1
           maxItems      = 30
@@ -64,7 +85,11 @@ publish {
         }
         {
           name          = dispersion
-          description   = "An array of atmospheric dispersion values."
+          description   = """
+          An array of atmospheric dispersion values.
+
+          *Discussion: The dispersion field is the calculated relative atmospheric dispersion at each wavelength after subtracting a reference dispersion at the reference wavelength. The dispersion is measured in arcseconds on the sky. The number of dispersion values provided must be exactly equal to the value of numElem. The IRIS CC will use the atmospheric dispersion values along with the weights and wavelengths to determine a power setting for the ADC.*
+          """
           type          = array
           minItems      = 1
           maxItems      = 30
@@ -81,6 +106,10 @@ publish {
       description       = """
       The TCS publishes a single new IRIS Imager Dispersion event each time a new target is to be acquired.
       Information is pertinent to the new target location.
+
+      *Discussion: The ADC should adjust to the values indicated by tcs.cm.iris.imgNewAtmDispersion until a tcs.cm.iris.pointingStatus event is published with state set to Tracking, and the same counter value. At that point, it should switch back to tracking imgCurAtmDispersion.*
+
+      *Discussion: See full descriptions of equivalent attributes in imgCurAtmDispersion*
       """
       archive           = true
       attributes        = [
@@ -94,7 +123,7 @@ publish {
         }
         {
           name          = orientation
-          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of ICRS."
+          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of FCRS<sub>IRIS-ROT</sub>."
           type          = double
           minimum       = -180
           maximum       = 180
@@ -157,6 +186,8 @@ publish {
       name              = oiwfs1CurAtmDispersion
       description       = """
        The TCS publishes the IRIS OIWFS dispersion information (one for each probe) at the current telescope location.
+
+      *Discussion: See full descriptions of equivalent attributes in imgCurAtmDispersion*
        """
       minRate           = 1
       maxRate           = 1
@@ -172,7 +203,7 @@ publish {
         }
         {
           name          = orientation
-          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of the ICRS."
+          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of the FCRS<sub>IRIS-ROT</sub>."
           type          = double
           minimum       = -180
           maximum       = 180
@@ -229,6 +260,10 @@ publish {
       description       = """
       The TCS publishes single new IRIS OIWFS Dispersion events (one for each probe) each time a new target is to be acquired.
       Information is pertinent to the new target location.
+
+      *Discussion: Each probe arm ADC should adjust to the values indicated by the correct tcs.cm.iris.oiwfsXNewAtmDispersion until the relevant tcs.cm.iris.oiwfsXpointingStatus event is published, with state set to Tracking, and the same counter value. At that point, it should switch back to tracking oiwfs1CurAtmDispersion. Note that each arm requires its own pointingStatus stream to enable subsets of the probes to acquire new stars while the remaining probes continue tracking.*
+
+      *Discussion: See full descriptions of equivalent attributes in imgCurAtmDispersion*
       """
       archive           = true
       attributes        = [
@@ -242,7 +277,7 @@ publish {
         }
         {
           name          = orientation
-          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of ICRS."
+          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of FCRS<sub>IRIS-ROT</sub>."
           type          = double
           minimum       = -180
           maximum       = 180
@@ -302,7 +337,9 @@ publish {
     {
       name              = oiwfs2CurAtmDispersion
       description       = """
-       The TCS publishes the IRIS OIWFS dispersion information (one for each probe) at the current telescope location.
+      The TCS publishes the IRIS OIWFS dispersion information (one for each probe) at the current telescope location.
+
+      *Discussion: See full descriptions of equivalent attributes in imgCurAtmDispersion*
        """
       minRate           = 1
       maxRate           = 1
@@ -318,7 +355,7 @@ publish {
         }
         {
           name          = orientation
-          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of the ICRS."
+          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of the FCRS<sub>IRIS-ROT</sub>."
           type          = double
           minimum       = -180
           maximum       = 180
@@ -375,6 +412,8 @@ publish {
       description       = """
       The TCS publishes single new IRIS OIWFS Dispersion events (one for each probe) each time a new target is to be acquired.
       Information is pertinent to the new target location.
+
+      *Discussion: See full descriptions of equivalent attributes in imgCurAtmDispersion and oiwfs1NewAtmDispersion*
       """
       archive           = true
       attributes        = [
@@ -388,7 +427,7 @@ publish {
         }
         {
           name          = orientation
-          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of ICRS."
+          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of FCRS<sub>IRIS-ROT</sub>."
           type          = double
           minimum       = -180
           maximum       = 180
@@ -450,6 +489,8 @@ publish {
       name              = oiwfs3CurAtmDispersion
       description       = """
        The TCS publishes the IRIS OIWFS dispersion information (one for each probe) at the current telescope location.
+
+      *Discussion: See full descriptions of equivalent attributes in imgCurAtmDispersion*
        """
       minRate           = 1
       maxRate           = 1
@@ -465,7 +506,7 @@ publish {
         }
         {
           name          = orientation
-          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of the ICRS."
+          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of the FCRS<sub>IRIS-ROT</sub>."
           type          = double
           minimum       = -180
           maximum       = 180
@@ -522,6 +563,8 @@ publish {
       description       = """
       The TCS publishes single new IRIS OIWFS Dispersion events (one for each probe) each time a new target is to be acquired.
       Information is pertinent to the new target location.
+
+      *Discussion: See full descriptions of equivalent attributes in imgCurAtmDispersion and oiwfs1NewAtmDispersion*
       """
       archive           = true
       attributes        = [
@@ -535,7 +578,7 @@ publish {
         }
         {
           name          = orientation
-          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of ICRS."
+          description   = "Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of FCRS<sub>IRIS-ROT</sub>."
           type          = double
           minimum       = -180
           maximum       = 180
@@ -596,6 +639,8 @@ publish {
       name              = oiwfs1pointingStatus
       description       = """
       The TCS publishes current pointing status events for each OIWFS probe arm independently, each time the state changes.
+
+      *Discussion: See full descriptions of equivalent attributes in tcs.pk.pointingStatus.*
       """
       archive           = true
       attributes        = [
@@ -616,6 +661,8 @@ publish {
       name              = oiwfs2pointingStatus
       description       = """
       The TCS publishes current pointing status events for each OIWFS probe arm independently, each time the state changes.
+
+      *Discussion: See full descriptions of equivalent attributes in tcs.pk.pointingStatus.*
       """
       archive           = true
       attributes        = [
@@ -636,6 +683,8 @@ publish {
       name              = oiwfs3pointingStatus
       description       = """
       The TCS publishes current pointing status events for each OIWFS probe arm independently, each time the state changes.
+
+      *Discussion: See full descriptions of equivalent attributes in tcs.pk.pointingStatus.*
       """
       archive           = true
       attributes        = [
@@ -656,6 +705,8 @@ publish {
       name              = instrumentRotatorAngle
       description       = """
       The TCS publishes the timestamped current IRIS instrument rotator angle.
+
+      *Discussion: During LGS, NGS or seeing limited operations, the IRIS instrument rotator will rotate to derotate the field, which rotates as the telescope tracks a target across the sky (a combination of parallactic angle and pupil rotation). In addition, the rotator angle may include an offset if the observer has requested a particular PA.*
       """
       minRate           = 20
       maxRate           = 20
@@ -682,6 +733,8 @@ publish {
       name              = pupilRotation
       description       = """
       The TCS publishes the timestamped current pupil rotation angle.
+
+      *Discussion: During LGS, NGS or seeing limited operations, the IRIS instrument rotator will correct for the combination of parallactic angle and pupil rotation, meaning that the pupil orientation will vary. The pupil mask rotators will need the current pupil rotation, likely after some linear transformation with constant coefficients, in order to keep a pupil mask aligned with the pupil image of the primary mirror.*
       """
       minRate           = 20
       maxRate           = 20
@@ -689,7 +742,7 @@ publish {
       attributes        = [
         {
           name          = pupilRotation
-          description   = "Current IRIS pupil rotation angle in the X,Y plane of the ICRS."
+          description   = "Current IRIS pupil rotation angle in the X,Y plane of the FCRS<sub>IRIS-ROT</sub>."
           type          = double
           minimum       = 90
           maximum       = 180
@@ -708,6 +761,8 @@ publish {
       name              = oiwfsProbeDemands
       description       = """
       The TCS publishes the timestamped focal plane locations and velocities for each IRIS OIWFS at some TBD time in the future.
+
+      *Discussion: During an observation, the TCS will provide the timestamped XY locations and velocities of the OIWFS sensors in the focal plane so that each OIWFS can accurately track its guide star.*
       """
       minRate           = 20
       maxRate           = 20
@@ -715,7 +770,7 @@ publish {
       attributes        = [
         {
           name          = oiwfs1Pos
-          description   = "2-element array holding x,y values in the ICRS."
+          description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
           type          = array
           dimensions: [2]
           units = mm
@@ -725,7 +780,7 @@ publish {
         }
         {
           name          = oiwfs2Pos
-          description   = "2-element array holding x,y values in the ICRS."
+          description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
           type          = array
           dimensions: [2]
           units = mm
@@ -735,7 +790,7 @@ publish {
         }
         {
           name          = oiwfs3Pos
-          description   = "2-element array holding x,y values in the ICRS."
+          description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
           type          = array
           dimensions: [2]
           units = mm
@@ -745,7 +800,7 @@ publish {
         }
         {
           name          = oiwfs1Vel
-          description   = "2-element array holding x,y values in the ICRS."
+          description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
           type          = array
           dimensions: [2]
           units = mm/s
@@ -755,7 +810,7 @@ publish {
         }
         {
           name          = oiwfs2Vel
-          description   = "2-element array holding x,y values in the ICRS."
+          description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
           type          = array
           dimensions: [2]
           units = mm/s
@@ -765,7 +820,7 @@ publish {
         }
         {
           name          = oiwfs3Vel
-          description   = "2-element array holding x,y values in the ICRS."
+          description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
           type          = array
           dimensions: [2]
           units = mm/s
@@ -786,6 +841,8 @@ publish {
       name              = odgwPosDemands
       description       = """
       The TCS publishes the timestamped focal plane locations for each IRIS ODGW at some TBD time in the future.
+
+      *During an observation, the TCS will provide the timestamped XY locations of the guide stars for ODGWs. Velocities are not required, as in the case of the OIWFS position streams, since window locations can be changed instantaneously.*
       """
       minRate           = 20
       maxRate           = 20
@@ -793,7 +850,7 @@ publish {
       attributes        = [
         {
           name          = odgw1Pos
-          description   = "2-element array holding x,y values in the ICRS."
+          description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
           type          = array
           dimensions: [2]
           units = mm
@@ -803,7 +860,7 @@ publish {
         }
         {
           name          = odgw2Pos
-          description   = "2-element array holding x,y values in the ICRS."
+          description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
           type          = array
           dimensions: [2]
           units = mm
@@ -813,7 +870,7 @@ publish {
         }
         {
           name          = odgw3Pos
-          description   = "2-element array holding x,y values in the ICRS."
+          description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
           type          = array
           dimensions: [2]
           units = mm
@@ -823,7 +880,7 @@ publish {
         }
         {
           name          = odgw4Pos
-          description   = "2-element array holding x,y values in the ICRS."
+          description   = "2-element array holding x,y values in the FCRS<sub>IRIS-ROT</sub>."
           type          = array
           dimensions: [2]
           units = mm

--- a/iris/subscribe-model.conf
+++ b/iris/subscribe-model.conf
@@ -1,0 +1,17 @@
+subsystem = TCS
+component = cmIRIS
+
+subscribe {
+          telemetry = [
+          {
+          subsystem = IRIS
+          component = imager-adc-assembly
+          name = odgwShift
+          }
+          {
+          subsystem = IRIS
+          component = oiwfs-adc-assembly
+          name = oiwfsShift
+          }
+          ]
+}

--- a/pk/component-model.conf
+++ b/pk/component-model.conf
@@ -1,0 +1,13 @@
+subsystem = TCS
+component = pk
+
+title = "Telescope Control Pointing Kernel"
+prefix = tcs.pk
+componentType = Assembly
+
+description = """
+This component publishes basic pointing information for the entire telescope.
+"""
+
+modelVersion = "1.0"  // version of model in use for component
+

--- a/pk/publish-model.conf
+++ b/pk/publish-model.conf
@@ -13,12 +13,20 @@ publish {
       attributes        = [
         {
           name          = state
-          description   = "Current state of the pointing system"
+          description   = """
+          Current state of the pointing system
+
+          *Discussion: Slewing and Tracking are the two normal values expected during science observations. InPosition is a state only expected during the day when the telescope points at a fixed Az, El.*
+          """
           enum          = [Slewing,Tracking,InPosition]
         }
         {
           name          = counter
-          description   = "Current target counter (incrementing with rollover)"
+          description   = """
+          Current target counter (incrementing with rollover)
+
+          *Discussion: When a pointingStatus event is published at the start of Tracking, the value of this counter can be compared with the equivalent values published in earlier newAtmDispersion events to determine whether a slew to a particular new target has concluded. If so, the relevant ADC can begin following curAtmDispersion streams again.*
+          """
           type          = long
         }
       ]

--- a/pk/publish-model.conf
+++ b/pk/publish-model.conf
@@ -1,0 +1,29 @@
+subsystem               = TCS
+component               = pk
+
+publish {
+
+  telemetry          = [
+    {
+      name              = pointingStatus
+      description       = """
+      The TCS publishes current telescope pointing status as an event each time the telescope pointing state changes.
+      """
+      archive           = true
+      attributes        = [
+        {
+          name          = state
+          description   = "Current state of the pointing system"
+          enum          = [Slewing,Tracking,InPosition]
+        }
+        {
+          name          = counter
+          description   = "Current target counter (incrementing with rollover)"
+          type          = long
+        }
+      ]
+    }
+
+  ]
+
+}

--- a/subsystem-model.conf
+++ b/subsystem-model.conf
@@ -1,0 +1,13 @@
+// TCS Subsystem
+
+subsystem = TCS
+title = "TELESCOPE CONTROL SYSTEM (TCS)"
+modelVersion = "1.0"
+
+description = """
+This document describes the API for the TMT Telescope Control System.
+
+The main functions of the TCS are 1) a command sequencer to control, synchronize, and monitor the telescope subsystems, 2) a pointing model to convert target RA and DEC positions into corrected subsystem demands, and 3) wavefront control software for seeing limited instruments and blending AO offloads.
+
+The TCS provides high level control for the telescope mount, enclosure, M1, M2, M3, instrument components (rotators, WFS probes, ADCs),the Global Metrology System (GMS), and the Commissioning and Acquisition System (CAGS). The TCS provides coordination of the following operating modes: initialization, slewing, pointing, acquisition, tracking, guiding, nodding/dithering, and halting. The TCS is synchronized with the instruments and AO systems via the Observatory Control Software.
+"""


### PR DESCRIPTION
This pull request is meant to be a literal translation of the TCD-IRIS ICD (CCR08) to model files (see most recent version of Document-25887 on TMT docushare). Obviously, the changes here affect only the portions of the interface implemented by TCS. For those items implemented by IRIS, see [the sister pull request for IRIS](https://github.com/chrisaj5/IRIS-Model-Files/pull/6).
