### PR TITLE
IRIS PDR-2: Additional proposal for TCS - IRIS ICD (for Science ADC and Cold Stop)

### DIFF
--- a/iris/component-model.conf
+++ b/iris/component-model.conf
@@ -9,9 +9,9 @@ description = """
 The TCS provides telemetry streams to control several components of IRIS:
 
 * **OIWFS probe arms**: The three arms are continuously positioned over guide stars.
-* **4 ADCs**: One fore each OIWFS probe arm, and one for the imager.
+* **4 ADCs**: One for each OIWFS probe arm, and one for the science (for both Imager and IFS).
 * **rotator**: IRIS is rotated to compensate sidereal rotation and changes in pupil rotation, thus maintaining a stable scientific image.
-* **rotating cold-stop**: rotating stage that masks the pupil inside the imager.
+* **Cold Stop**: The cold stop masks out the thermal radiation from the telescope structure. The maskof the cold stop has to align with the telescope pupil. Because the instrument rotator compensates both sidereal rotation and pupil rotation, the cold stop rotary stage inside the instrument has to negate the rotation caused by sidereal rotation. The X/Y position of the mask has to be also adjusted depending on the instrument rotator angle to compensate the misalignment between the insturment rotator and the instrument optical path (TBD).
 """
 
 modelVersion = "1.1"  // version of model in use for component

--- a/iris/component-model.conf
+++ b/iris/component-model.conf
@@ -11,7 +11,7 @@ The TCS provides telemetry streams to control several components of IRIS:
 * **OIWFS probe arms**: The three arms are continuously positioned over guide stars.
 * **4 ADCs**: One for each OIWFS probe arm, and one for the science (for both Imager and IFS).
 * **rotator**: IRIS is rotated to compensate sidereal rotation and changes in pupil rotation, thus maintaining a stable scientific image.
-* **Cold Stop**: The cold stop masks out the thermal radiation from the telescope structure. The maskof the cold stop has to align with the telescope pupil. Because the instrument rotator compensates both sidereal rotation and pupil rotation, the cold stop rotary stage inside the instrument has to negate the rotation caused by sidereal rotation. The X/Y position of the mask has to be also adjusted depending on the instrument rotator angle to compensate the misalignment between the insturment rotator and the instrument optical path (TBD).
+* **Cold Stop**: The cold stop masks out the thermal radiation from the telescope structure. The mask of the cold stop has to align with the telescope pupil.
 """
 
 modelVersion = "1.1"  // version of model in use for component

--- a/iris/publish-model.conf
+++ b/iris/publish-model.conf
@@ -439,8 +439,6 @@ publish {
       name              = pupilRotation
       description       = """
       The TCS publishes the timestamped current pupil rotation angle.
-
-      *Discussion: During LGS, NGS or seeing limited operations, the IRIS instrument rotator will correct for the combination of parallactic angle and pupil rotation, meaning that the pupil orientation will vary. The pupil mask rotators will need the current pupil rotation, likely after some linear transformation with constant coefficients, in order to keep a pupil mask aligned with the pupil image of the primary mirror.*
       """
       minRate           = 20
       maxRate           = 20

--- a/iris/publish-model.conf
+++ b/iris/publish-model.conf
@@ -5,63 +5,15 @@ publish {
 
   events          = [
     {
-      name              = parallacticAngle
-      description       = """
-      The TCS publishes the parallactic angle at the target telescope location.
-
-      **TBD**: The event must be issued 50 ms before the parallactic angle becomes valid considering the time for the event propagation over the network and additional latency caused by IRIS software and control system.
-      """
-      minRate           = 20
-      maxRate           = 20
-      archive           = true
-      attributes        = [
-        {
-          name          = parallacticAngle
-          description   = """
-          The parallactic angle at the target telescope location in the XY plane of the FCRS<sub>IRIS-ROT</sub>. The parallactic angle is the angle formed at a point on the sky between a great circle between the point and the zenith, and a great circle between the piont and the celestial pole.
-
-          This is the same as the zenith direction (the orientation of the axis of dispersion due to atmospheric refraction) in the FCRS<sub>IRIS-ROT</sub>
-
-           *Discussion: During LGS, NGS or seeing limited operations, the IRIS Imager ADC prism rotation angles are updated based on the Imager Atmospheric Dispersion data. This angle is used to align the ADC axis of correction along the axis of dispersion.*
-          """
-          type          = double
-          minimum       = -180
-          maximum       = 180
-          units         = degrees
-        }
-        {
-          name          = pointingstate
-          description   = """
-          Current state of the event stream
-
-          *Discussion: SLEWING and TRACKING are the two normal values expected during science observations. INPOSITION is a state only expected during the day when the telescope points at a fixed Az, El.*
-          """
-          enum          = [SLEWING,TRACKING,INPOSITION]
-        }      
-        {
-          name          = counter
-          description   = "Unique TCS target counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
-          type          = long
-        }
-        {
-          name          = timestamp
-          description   = """
-          Time when valid (units and epoch are TBD)
-
-          *Discussion: The accuracy of the timestamp shall be better than 100 us, which is the accuracy that software PTP daemon can achieve (ref.: [TMT Software Design Document (Volume 2 of 2) (TMT.SFT.TEC.12.016.REL05)](https://docushare.tmt.org/docushare/dsweb/Get/Document-24358)).*
-
-          *Discussion: Originally, the type was defined as "double", but now it is "long" (64-bit integer). The significand part of double value has 52 bits, which means it has effectively 53 bits precision. Assuming that the resolution of this timestamp is microsecond (e.g. gettimeofday() function returns the current time in microsecond resolution), and assuming the epoch is 1858-11-17 12:00:00 UT (MJD), a single double variable can count the time until year 2143 (=~ 1858 + 2^53 / 365 / 24 / 60 / 60 / 1000 / 1000) in microsecond resolution. After that, the time resolution will be worse. This is probably OK considering TMT lifetime, but the operation system normally reports the time as an integer value(s) anyway. TCS does not have to convert it to double which has less precision than 64-bit integer.*
-          """
-          units         = mjd
-          type          = long
-        }
-      ]
-    }
-    {
       name              = imgAtmDispersion
       description       = """
        The TCS publishes the IRIS imager dispersion information at the target telescope location.
+
        The entire event is published atomically so that all published subcomponents are synchronized.
+
+       *Discussion: For sidereal tracking, the maximum rotation velocity of ADC prisms caused by the orientation change (= the change rate of the parallactic angle) is 0.225 deg/s, which happens when observing a target that transits 1 degree south from the zenith. The current required position accuracy is [+/- 0.28 deg](https://docushare.tmt.org/docushare/dsweb/Get/Document-57487/DN%20IRIS.IMG.ADC_REL01.pdf), so 1 Hz of update rate should be enough. If IRIS will need finer time granuality to frequently control the mechanisms, IRIS software should perform interpolation internally using the new event and the past events. If we really need to increase the update rate of this event in the future for better accuracy, there are two options: increase the update rate of this telemetry, or split "orientation" attribute into a separate event because the rotation velocity caused by the atmospheric correction is likely to be much slower than the velocity caused by the orientation change.*
+
+       *Discussion: It is expected that this event is published two ticks (= 2 seconds in case the update rate of this event is 1 Hz) before the time indicated by "timestamp" attribute. This event shall be published, at least, one tick before the time indicated by "timestamp" attribute to allow IRIS to perform interpolation of "orientation". Considering the calculation time to perform interpolation and margin for communication & software delay, it should be one more tick before, hence two ticks in total.*
        """
       minRate           = 1
       maxRate           = 1
@@ -78,6 +30,19 @@ publish {
           minimum       = 0.5
           maximum       = 3.0
           units         = microns
+        }
+        {
+          name          = orientation
+          description   = """Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of the FCRS<sub>IRIS-ROT</sub>.
+
+          *Discussion: For conventional field rotation tracking observations, this value will be the same as the parallactic angle (or its negative). This is because the ADC is inside the instrument, and the angle of the instrument rotator is a combination of parallactic angle and pupil rotation. The ADC just needs to negate the parallactic angle caused by the insturment rotator. This value may include an offset if the observer has requested a particular zenith direction in the image.*
+
+          *Discussion:  If we need to support pupil rotation tracking mode (= fixed pupil mode, or ADI mode) in the future, this value should be the zenith direction in the image specified by the observer. This should be fixed during the observation because the instrument rotator is supposed to compensate the pupil rotation.*
+"""
+          type          = double
+          minimum       = -180
+          maximum       = 180
+          units         = degrees
         }
         {
           name          = wavelength
@@ -438,7 +403,9 @@ publish {
     {
       name              = pupilRotation
       description       = """
-      The TCS publishes the timestamped current pupil rotation angle.
+      The TCS publishes the timestamped future pupil rotation angle.
+
+      **TBD**: This event shall be issued 50 ms before the time indicated by "timestamp" attribute considering the time for the event propagation over the network and additional latency caused by IRIS software and control system.
       """
       minRate           = 20
       maxRate           = 20
@@ -446,9 +413,14 @@ publish {
       attributes        = [
         {
           name          = pupilRotation
-          description   = "Current IRIS pupil rotation angle in the X,Y plane of the FCRS<sub>IRIS-ROT</sub>."
+          description   = """Future IRIS pupil rotation angle in the X,Y plane of the FCRS<sub>IRIS-ROT</sub> that will be valid at the time indicated by "timestamp" attribute.
+
+          *Discussion: For conventional field rotation tracking observations, this value will be the same as the parallactic angle (or its negative). This is because the cold stop is inside the instrument, and the angle of the instrument rotator is a combination of parallactic angle and pupil rotation. The cold stop just needs to negate the parallactic angle caused by the insturment rotator. This value may include an offset if the observer has requested a particular zenith direction in the image.*
+
+          *Discussion:  If we need to support pupil rotation tracking mode (= fixed pupil mode, or ADI mode) in the future, this value should be the zenith direction in the image specified by the observer. This should be fixed during the observation because the instrument rotator is supposed to compensate the pupil rotation.*
+"""
           type          = double
-          minimum       = 90
+          minimum       = -180
           maximum       = 180
           units         = degrees
         }

--- a/iris/publish-model.conf
+++ b/iris/publish-model.conf
@@ -8,6 +8,8 @@ publish {
       name              = parallacticAngle
       description       = """
       The TCS publishes the parallactic angle at the target telescope location.
+
+      **TBD**: The event must be issued 50 ms before the parallactic angle becomes valid considering the time for the event propagation over the network and additional latency caused by IRIS software and control system.
       """
       minRate           = 20
       maxRate           = 20

--- a/iris/publish-model.conf
+++ b/iris/publish-model.conf
@@ -5,6 +5,51 @@ publish {
 
   events          = [
     {
+      name              = parallacticAngle
+      description       = """
+      The TCS publishes the parallactic angle at the target telescope location.
+      """
+      minRate           = 20
+      maxRate           = 20
+      archive           = true
+      attributes        = [
+        {
+          name          = parallacticAngle
+          description   = """
+          The parallactic angle at the target telescope location in the XY plane of the FCRS<sub>IRIS-ROT</sub>. The parallactic angle is the angle formed at a point on the sky between a great circle between the point and the zenith, and a great circle between the piont and the celestial pole.
+
+          This is the same as the zenith direction (the orientation of the axis of dispersion due to atmospheric refraction) in the FCRS<sub>IRIS-ROT</sub>
+
+           *Discussion: During LGS, NGS or seeing limited operations, the IRIS Imager ADC prism rotation angles are updated based on the Imager Atmospheric Dispersion data. This angle is used to align the ADC axis of correction along the axis of dispersion.*
+          """
+          type          = double
+          minimum       = -180
+          maximum       = 180
+          units         = degrees
+        }
+        {
+          name          = pointingstate
+          description   = """
+          Current state of the event stream
+
+          *Discussion: SLEWING and TRACKING are the two normal values expected during science observations. INPOSITION is a state only expected during the day when the telescope points at a fixed Az, El.*
+          """
+          enum          = [SLEWING,TRACKING,INPOSITION]
+        }      
+        {
+          name          = counter
+          description   = "Unique TCS target counter that is incremented (with rollover) each time a new target is acquired. TBD whether this is required."
+          type          = long
+        }
+        {
+          name          = timestamp
+          description   = "Time when valid (units TBD)"
+          units         = mjd
+          type          = double
+        }
+      ]
+    }
+    {
       name              = imgAtmDispersion
       description       = """
        The TCS publishes the IRIS imager dispersion information at the target telescope location.
@@ -25,18 +70,6 @@ publish {
           minimum       = 0.5
           maximum       = 3.0
           units         = microns
-        }
-        {
-          name          = orientation
-          description   = """
-          Orientation of the axis of dispersion due to atmospheric refraction defined in the XY plane of the FCRS<sub>IRIS-ROT</sub>.
-
-           *Discussion: During LGS, NGS or seeing limited operations, the IRIS Imager ADC prism rotation angles are updated based on the Imager Atmospheric Dispersion data. The orientation angle is used to align the ADC axis of correction along the axis of dispersion.*
-          """
-          type          = double
-          minimum       = -180
-          maximum       = 180
-          units         = degrees
         }
         {
           name          = wavelength

--- a/iris/publish-model.conf
+++ b/iris/publish-model.conf
@@ -43,9 +43,15 @@ publish {
         }
         {
           name          = timestamp
-          description   = "Time when valid (units TBD)"
+          description   = """
+          Time when valid (units and epoch are TBD)
+
+          *Discussion: The accuracy of the timestamp shall be better than 100 us, which is the accuracy that software PTP daemon can achieve (ref.: [TMT Software Design Document (Volume 2 of 2) (TMT.SFT.TEC.12.016.REL05)](https://docushare.tmt.org/docushare/dsweb/Get/Document-24358)).*
+
+          *Discussion: Originally, the type was defined as "double", but now it is "long" (64-bit integer). The significand part of double value has 52 bits, which means it has effectively 53 bits precision. Assuming that the resolution of this timestamp is microsecond (e.g. gettimeofday() function returns the current time in microsecond resolution), and assuming the epoch is 1858-11-17 12:00:00 UT (MJD), a single double variable can count the time until year 2143 (=~ 1858 + 2^53 / 365 / 24 / 60 / 60 / 1000 / 1000) in microsecond resolution. After that, the time resolution will be worse. This is probably OK considering TMT lifetime, but the operation system normally reports the time as an integer value(s) anyway. TCS does not have to convert it to double which has less precision than 64-bit integer.*
+          """
           units         = mjd
-          type          = double
+          type          = long
         }
       ]
     }
@@ -136,9 +142,9 @@ publish {
         }
         {
           name          = timestamp
-          description   = "Time when valid (units TBD)"
+          description   = "Time when valid (units and epoch are TBD)"
           units         = mjd
-          type          = double
+          type          = long
         }
       ]
     }
@@ -218,9 +224,9 @@ publish {
         }
         {
           name          = timestamp
-          description   = "Time when valid (units TBD)"
+          description   = "Time when valid (units and epoch are TBD)"
           units         = mjd
-          type          = double
+          type          = long
         }
       ]
     }
@@ -300,9 +306,9 @@ publish {
         }
         {
           name          = timestamp
-          description   = "Time when valid (units TBD)"
+          description   = "Time when valid (units and epoch are TBD)"
           units         = mjd
-          type          = double
+          type          = long
         }
       ]
     }
@@ -382,9 +388,9 @@ publish {
         }
         {
           name          = timestamp
-          description   = "Time when valid (units TBD)"
+          description   = "Time when valid (units and epoch are TBD)"
           units         = mjd
-          type          = double
+          type          = long
         }
       ]
     }
@@ -420,9 +426,9 @@ publish {
         }
         {
           name          = timestamp
-          description   = "Time when valid (units TBD)"
+          description   = "Time when valid (units and epoch are TBD)"
           units         = mjd
-          type          = double
+          type          = long
         }
       ]
     }
@@ -458,9 +464,9 @@ publish {
         }
         {
           name          = timestamp
-          description   = "Time when valid (units TBD)"
+          description   = "Time when valid (units and epoch are TBD)"
           units         = mjd
-          type          = double
+          type          = long
         }
       ]
     }
@@ -538,9 +544,9 @@ publish {
         }
         {
           name          = timestamp
-          description   = "Time when valid (units TBD)"
+          description   = "Time when valid (units and epoch are TBD)"
           type          = double
-          units         = mjd
+          units         = long
         }
       ]
     }
@@ -638,9 +644,9 @@ publish {
         }        
         {
           name          = timestamp
-          description   = "Time when valid (units TBD)"
-          type          = double
+          description   = "Time when valid (units and epoch are TBD)"
           units         = mjd
+          type          = long
         }
       ]
     }


### PR DESCRIPTION
This PR is related to tmtsoftware/IRIS-Model-Files#36.

The summary of the changes is following:

- Defined a new event stream "parallacticAngle" mainly for Cold Stop. Science ADC also listens to it.
- Changed the type of the timestamp from "double" to "long".
- Updated some descriptions.